### PR TITLE
Update to Warp 0.3 with Tokio v1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "warp-embed"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Okamura Yasunobu <okamura@informationsea.info>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,12 +15,12 @@ categories = ["web-programming::http-server"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-warp = { version = "0.2" }
+warp = { version = "0.3" }
 rust-embed = "5"
-mime_guess = "1"
+mime_guess = "2"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.1", features = ["full"] }
 pretty_env_logger = "0.4"
 log = "0.4"
 clap = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ pub fn embed_with_config<A: rust_embed::RustEmbed>(
 }
 
 fn create_reply(data: Cow<'static, [u8]>, actual_name: &str) -> impl Reply {
-    let suggest = mime_guess::guess_mime_type(actual_name);
+    let suggest = mime_guess::from_path(actual_name).first_or_octet_stream();
     warp::reply::with_header(EmbedFile { data }, "Content-Type", suggest.to_string())
 }
 


### PR DESCRIPTION
Many thanks for creating this crate! 

I created this small PR to upgrade it to Warp 3.0 (released 9 days ago) which uses Tokio v1. 