### PR TITLE
Avoid enabling warp default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-warp = { version = "0.3" }
+warp = { version = "0.3", default-features = false }
 rust-embed = "8"
 mime_guess = "2"
 


### PR DESCRIPTION
Hi!

At the moment `warp-embed` depends on `warp` with default features, which implicitly enables websocket support when depending on `warp-embed`.

Setting `default-features = false` avoids this problem.